### PR TITLE
Feature/161 drop legacy ruby rails

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-branch: [rails6, rails7, rails7-shakapacker]
+        test-branch: [rails7, rails7-shakapacker]
     timeout-minutes: 20
     steps:
     - name: Checkout

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,13 +13,23 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.1', '3.2', '3.3']
+        channel: ['stable']
+
+        include:
+          - ruby-version: 'head'
+            channel: 'experimental'
+
+    continue-on-error: ${{ matrix.channel != 'stable' }}
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.7
+        ruby-version: '3.3'
         bundler-cache: true
     - name: Test with Rake
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
-Nothing.
+- Drop Support for Webpacker, Legacy Ruby (< 3.0), and Legacy Rails (< 7.0).  [#163](https://github.com/jamesmartin/inline_svg/pull/163). Thanks, [@tagliala](https://github.com/tagliala)
 
 ## [1.10.0] - 2024-09-03
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,9 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in inline_svg.gemspec
 gemspec
+
+gem "bundler"
+gem "pry"
+gem "rake"
+gem "rspec"
+gem "rubocop"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Styling a SVG document with CSS for use on the web is most reliably achieved by
 [adding classes to the document and
 embedding](http://css-tricks.com/using-svg/) it inline in the HTML.
 
-This gem adds Rails helper methods (`inline_svg_tag` and `inline_svg_pack_tag`) that read an SVG document (via Sprockets or Webpacker, so works with the Rails Asset Pipeline), applies a CSS class attribute to the root of the document and
+This gem adds Rails helper methods (`inline_svg_tag` and `inline_svg_pack_tag`) that read an SVG document (via Sprockets or Shakapacker, so works with the Rails Asset Pipeline), applies a CSS class attribute to the root of the document and
 then embeds it into a view.
 
 Inline SVG supports:
@@ -43,7 +43,7 @@ Or install it yourself as:
 # Sprockets
 inline_svg_tag(file_name, options={})
 
-# Webpacker
+# Shakapacker
 inline_svg_pack_tag(file_name, options={})
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,7 @@ embedding](http://css-tricks.com/using-svg/) it inline in the HTML.
 This gem adds Rails helper methods (`inline_svg_tag` and `inline_svg_pack_tag`) that read an SVG document (via Sprockets or Shakapacker, so works with the Rails Asset Pipeline), applies a CSS class attribute to the root of the document and
 then embeds it into a view.
 
-Inline SVG supports:
-
-- [Rails 5](http://weblog.rubyonrails.org/2016/6/30/Rails-5-0-final/) (from [v0.10.0](https://github.com/jamesmartin/inline_svg/releases/tag/v0.10.0))
-- [Rails 6](https://weblog.rubyonrails.org/2019/4/24/Rails-6-0-rc1-released/) with Sprockets or Webpacker (from [v1.5.2](https://github.com/jamesmartin/inline_svg/releases/tag/v1.5.2)).
-- [Rails 7](https://weblog.rubyonrails.org/2021/12/6/Rails-7-0-rc-1-released/)
-
-Inline SVG no longer officially supports Rails 3 or Rails 4 (although they may still work). In order to reduce the maintenance cost of this project we now follow the [Rails Maintenance Policy](https://guides.rubyonrails.org/maintenance_policy.html).
+Inline SVG supports Rails 7.x with Propshaft, Sprockets, or Shakapacker
 
 ## Changelog
 

--- a/inline_svg.gemspec
+++ b/inline_svg.gemspec
@@ -18,13 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.2"
-  spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "rubocop"
+  spec.metadata['rubygems_mfa_required'] = 'true'
+  spec.required_ruby_version = '>= 3.1'
 
-  spec.add_runtime_dependency "activesupport", ">= 3.0"
-  spec.add_runtime_dependency "nokogiri", ">= 1.6"
+  spec.add_dependency "activesupport", ">= 7.0"
+  spec.add_dependency "nokogiri", ">= 1.16"
 end

--- a/lib/inline_svg/action_view/helpers.rb
+++ b/lib/inline_svg/action_view/helpers.rb
@@ -22,15 +22,6 @@ module InlineSvg
 
       private
 
-      def backwards_compatible_html_escape(filename)
-        # html_escape_once was introduced in newer versions of Rails.
-        if ERB::Util.respond_to?(:html_escape_once)
-          ERB::Util.html_escape_once(filename)
-        else
-          ERB::Util.html_escape(filename)
-        end
-      end
-
       def render_inline_svg(filename, transform_params={})
         begin
           svg_file = read_svg(filename)
@@ -60,7 +51,7 @@ module InlineSvg
 
       def placeholder(filename)
         css_class = InlineSvg.configuration.svg_not_found_css_class
-        not_found_message = "'#{backwards_compatible_html_escape(filename)}' #{extension_hint(filename)}"
+        not_found_message = "'#{ERB::Util.html_escape_once(filename)}' #{extension_hint(filename)}"
 
         if css_class.nil?
           return "<svg><!-- SVG file not found: #{not_found_message}--></svg>".html_safe

--- a/lib/inline_svg/version.rb
+++ b/lib/inline_svg/version.rb
@@ -1,3 +1,3 @@
 module InlineSvg
-  VERSION = "1.10.0"
+  VERSION = "2.0.0"
 end

--- a/lib/inline_svg/webpack_asset_finder.rb
+++ b/lib/inline_svg/webpack_asset_finder.rb
@@ -23,12 +23,7 @@ module InlineSvg
     private
 
     def asset_helper
-      @asset_helper ||=
-        if defined?(::Shakapacker)
-          ::Shakapacker
-        else
-          ::Webpacker
-        end
+      @asset_helper ||= ::Shakapacker
     end
 
     def dev_server_asset(file_path)

--- a/spec/finds_asset_paths_spec.rb
+++ b/spec/finds_asset_paths_spec.rb
@@ -63,13 +63,13 @@ describe InlineSvg::FindsAssetPaths do
 
   context "when webpack finder returns an object with a relative asset path" do
     it "returns the fully qualified file path" do
-      webpacker = double('WebpackerDouble')
+      shakapacker = double('ShakapackerDouble')
 
-      expect(webpacker).to receive(:find_asset).with('some-file').
+      expect(shakapacker).to receive(:find_asset).with('some-file').
         and_return(double(filename: Pathname('/full/path/to/some-file')))
 
       InlineSvg.configure do |config|
-        config.asset_finder = webpacker
+        config.asset_finder = shakapacker
       end
 
       expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq Pathname('/full/path/to/some-file')
@@ -78,13 +78,13 @@ describe InlineSvg::FindsAssetPaths do
 
   context "when webpack finder returns an object with an absolute http asset path" do
     it "returns the fully qualified file path" do
-      webpacker = double('WebpackerDouble')
+      shakapacker = double('ShakapackerDouble')
 
-      expect(webpacker).to receive(:find_asset).with('some-file').
+      expect(shakapacker).to receive(:find_asset).with('some-file').
         and_return(double(filename: Pathname('https://my-fancy-domain.test/full/path/to/some-file')))
 
       InlineSvg.configure do |config|
-        config.asset_finder = webpacker
+        config.asset_finder = shakapacker
       end
 
       expect(InlineSvg::FindsAssetPaths.by_filename('some-file')).to eq Pathname('https://my-fancy-domain.test/full/path/to/some-file')

--- a/spec/webpack_asset_finder_spec.rb
+++ b/spec/webpack_asset_finder_spec.rb
@@ -4,16 +4,6 @@ describe InlineSvg::WebpackAssetFinder do
   context "when the file is not found" do
     it "returns nil" do
       stub_const('Rails', double('Rails').as_null_object)
-      stub_const('Webpacker', double('Webpacker').as_null_object)
-      expect(::Webpacker.manifest).to receive(:lookup).with('some-file').and_return(nil)
-
-      expect(described_class.find_asset('some-file').pathname).to be_nil
-    end
-  end
-
-  context "when Shakapacker is defined" do
-    it "uses the new spelling" do
-      stub_const('Rails', double('Rails').as_null_object)
       stub_const('Shakapacker', double('Shakapacker').as_null_object)
       expect(::Shakapacker.manifest).to receive(:lookup).with('some-file').and_return(nil)
 


### PR DESCRIPTION
Drop legacy Ruby and Rails support

Also:
- Opt-in for MFA (security)
- Move development gems to Gemfile

Close https://github.com/jamesmartin/inline_svg/issues/161

---

Modernize CI 

Also:

- Run GitHub Actions on PRs
- Set explicit permissions to read for better security. Workflows run
  with extended set of permissions by default. By specifying
  any permission explicitly, all others are set to none.
- Update actions to prevent deprecation warning messages
- Remove redundant `gem install bundler` (bundler is already available after
  setup-ruby action)
- Test against Rails 7.1 / Shakapacker 8 (allow failures)
- Test against multiple Ruby version
- Experimental tests against ruby-head

---

